### PR TITLE
Document how to consume the library in an iOS app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+Swift wrapper around the Zano C++ wallet library, distributed as `zano_ios.xcframework`. This repo builds the framework and ships a SwiftUI sample app that exercises the API.
+
+User-facing setup and workflow instructions live in [README.md](README.md). In particular, the **"Updating to a new Zano library version"** section in the README is the end-to-end recipe for syncing C++ deps from upstream, rebuilding the xcframework, and propagating the change to the consuming app. This file covers what the README doesn't — internal code layout and interop rules.
+
+## Repo layout
+
+- [zano-ios/](zano-ios/) — framework target sources.
+  - [zano.swift](zano-ios/zano.swift) — public Swift API (`ZanoWallet` enum, free functions).
+  - [StringConversionUtils.swift](zano-ios/StringConversionUtils.swift) — Swift ↔ C++ `std::string` marshalling via `CxxStdlib`.
+  - [Internal/ZanoCore.swift](zano-ios/Internal/ZanoCore.swift) — wraps the Objective-C bridge.
+  - [Internal/Objective-C/ZanoBridgeShim.{h,mm}](zano-ios/Internal/Objective-C/) — Obj-C++ shim into `plain_wallet_api`.
+  - [wallet/module.modulemap](zano-ios/wallet/module.modulemap) — exposes `plain_wallet_api.h` from the libwallet xcframework.
+  - `Dependencies/` — **gitignored**, see below.
+- [zano-ios-sample/](zano-ios-sample/) — SwiftUI sample app consuming the framework.
+  - [JSONRPC/](zano-ios-sample/JSONRPC/) — small JSON-RPC layer for the wallet `invoke` proxy.
+- [zano-iosTests/](zano-iosTests/) — framework unit tests.
+- [zano-ios-sampleTests/](zano-ios-sampleTests/), [zano-ios-sampleUITests/](zano-ios-sampleUITests/) — sample-app unit and UI tests.
+- [script.sh](script.sh) — xcframework build entrypoint.
+
+## Dependencies are gitignored
+
+[.gitignore](.gitignore) excludes `zano-ios/Dependencies/`. The prebuilt C++ xcframeworks (`libboost`, `libcommon.a`, `libcrypto_.a`, `libcurrency_core.a`, `libwallet.a`, `libz.a`, `openssl/`) live there at build time but never appear in `git status`.
+
+If a build fails with missing modules or unresolved C++ symbols, the deps directory is the first place to check — don't go hunting in the Swift code. See the README's update workflow for how to populate it (sync from `upstream` remote or build from `hyle-team/zano_native_lib_package_`).
+
+## Build & test
+
+Build the xcframework (default `Release`):
+
+```sh
+./script.sh            # Release — sets BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+./script.sh Debug      # Debug — BUILD_LIBRARY_FOR_DISTRIBUTION=NO
+VERBOSE=true ./script.sh  # full xcodebuild output
+```
+
+Output: `./zano_ios.xcframework`. The script archives for both `iOS` and `iOS Simulator` then runs `-create-xcframework`.
+
+Run the framework tests:
+
+```sh
+xcodebuild test -project zano-ios.xcodeproj -scheme zano-ios \
+  -destination 'platform=iOS Simulator,name=iPhone 15'
+```
+
+Only one shared scheme exists: `zano-ios`. The sample-app tests run from the sample target inside Xcode.
+
+## C++ interop rules
+
+The bridge is layered: Swift public API → Swift internal → Obj-C++ shim → C++ `plain_wallet_api`. A few non-obvious rules:
+
+- **Never pass `String` directly to the C++ layer.** Use `StringConversionUtils.swiftStringToCppString(_:)` — it allocates, copies, and deallocates the intermediate buffer for you. Calling the lower-level `swiftStringToStdString` without `deallocate` leaks.
+- **Public surface lives in [zano.swift](zano-ios/zano.swift) only.** `ZanoCore` and the `ZanoBridgeShim` are `internal import`s — don't expose their types from public functions.
+- **`asyncCallMethods` in [zano.swift:13](zano-ios/zano.swift)** enumerates which `invoke` targets dispatch async (`close`, `open`, `restore`, `get_seed_phrase_info`, `invoke`, `get_wallet_status`). When wrapping new wallet methods, update this list if they block.
+- **CxxStdlib interop is enabled** (`internal import CxxStdlib`). This requires Swift 5.9+ and the framework target's C++ interoperability build setting; don't disable it.
+
+## Code style
+
+Defer to [.swift-format](.swift-format). Key choices baked in there: 4-space indent, 100-col line length, ordered imports, lowerCamelCase enforced, no block comments, ASCII identifiers only. Run `swift-format` before committing.
+
+Ruby 3.2.4 is pinned in [.tool-versions](.tool-versions) for tooling around the iOS build (asdf/mise).
+
+## Consumer setup and library updates
+
+See [README.md](README.md). The two things worth repeating because they cause silent failures:
+
+- Consumers must set `zano_ios.xcframework` to **Embed & Sign** — "Do Not Embed" crashes on launch in release builds.
+- A library version bump is a **two-PR workflow**: one PR here (rebuilt artifact) and one in the consuming app (artifact copy + consumer adjustments), linked as blockers.

--- a/README.md
+++ b/README.md
@@ -1,32 +1,78 @@
-# zano_native_lib_packages  
+# zano_native_lib_package_ios
 
-A Swift wrapper around the Zano C++ library. Use it to create iOS apps that interact with the Zano wallet.  
+A Swift wrapper around the Zano C++ wallet library, distributed as a prebuilt `zano_ios.xcframework` for iOS. The public Swift API is the `ZanoWallet` enum in [zano-ios/zano.swift](zano-ios/zano.swift). For a runnable usage example, see [zano-ios-sample/](zano-ios-sample/).
 
-## How to Generate XCFrameworks for Your iOS App  
+## Consuming `zano_ios.xcframework` from an iOS app
 
-### Prerequisites  
+This is how [`wallet-ios`](https://github.com/bitcoin-portal/wallet-ios) consumes the library, and how any other iOS app should too. There is **no** Swift Package or CocoaPods distribution — the xcframework is dropped into the consuming repo directly.
 
-1. Clone the repository:  
-   ```sh
-   git clone https://github.com/hyle-team/zano_native_lib_package_ios
-   ```
-2. Move the XCFrameworks from the [`Dependencies`](https://github.com/hyle-team/zano_native_lib_package_ios/tree/main/Dependencies) folder into your iOS app project.  
-   - Alternatively, you can generate the dependencies from [`zano_native_lib_package_`](https://github.com/hyle-team/zano_native_lib_package_).  
+### 1. Add the xcframework
 
-   **Note:** This step can be skipped if the dependencies are under 100MB, or if we use GitHub LFS for larger files.  
+Copy `zano_ios.xcframework` into your app project. In `wallet-ios` it lives at:
 
-### Generating XCFrameworks for Your iOS App (Swift)  
+```
+BitcoinComWallet/Dependencies/zano_ios.xcframework
+```
 
-1. Run the script:  
-   ```sh
-   ./script.sh
-   ```
-   This will generate `zano_ios.xcframework` in the project directory.  
-2. Move `zano_ios.xcframework` to your iOS app project.  
+The xcframework bundles every transitive C++ dependency (`libboost`, `libwallet`, `libcrypto_`, etc.). You do **not** need to add anything from this repo's `zano-ios/Dependencies/` to your app — those are build-time-only inputs to `script.sh`.
 
-### Setting Up Embedded Binaries  
+### 2. Link and embed in Xcode
 
-1. Open your project settings in Xcode.  
-2. Go to the **General** tab.  
-3. Under **Embedded Binaries**, set `zano_ios.xcframework` to **Embed & Sign**.  
-   - This prevents crashes in production builds.  
+In your app target's **General** tab → **Frameworks, Libraries, and Embedded Content**:
+
+1. Add `zano_ios.xcframework`.
+2. Set it to **Embed & Sign**.
+
+> ⚠️ **Embed & Sign is required.** "Do Not Embed" builds will run on the simulator but crash on launch in TestFlight / App Store builds.
+
+### 3. Use the API from Swift
+
+```swift
+import zano_ios
+
+let json = ZanoWallet.InitIpPort(
+    ip: "127.0.0.1",
+    port: "11211",
+    working_dir: NSTemporaryDirectory(),
+    log_level: 0
+)
+```
+
+All `ZanoWallet` methods return a JSON string from the underlying C++ wallet API. The sample app shows one approach to decoding these — see [zano-ios-sample/ZanoService.swift](zano-ios-sample/ZanoService.swift) and [zano-ios-sample/JSONRPC/](zano-ios-sample/JSONRPC/).
+
+The methods listed in `asyncCallMethods` ([zano-ios/zano.swift:13](zano-ios/zano.swift)) dispatch asynchronously inside the C++ layer; everything else is synchronous. Call them off the main thread.
+
+## Updating the xcframework shipped with `wallet-ios`
+
+When this library changes, rebuild and replace the copy in `wallet-ios`:
+
+```sh
+# In this repo:
+./script.sh                                  # produces ./zano_ios.xcframework
+
+# Then in wallet-ios:
+rm -rf BitcoinComWallet/Dependencies/zano_ios.xcframework
+cp -R ../zano_native_lib_package_ios/zano_ios.xcframework \
+      BitcoinComWallet/Dependencies/
+```
+
+Commit the replaced `zano_ios.xcframework` in `wallet-ios` — it is checked in directly, there is no remote artifact.
+
+## Building the xcframework
+
+```sh
+./script.sh           # Release (default) — BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+./script.sh Debug     # Debug
+VERBOSE=true ./script.sh   # full xcodebuild output
+```
+
+Output is `./zano_ios.xcframework` at the repo root.
+
+> 📦 **Fresh clones need the C++ deps.** `zano-ios/Dependencies/` is gitignored and must be populated with the prebuilt C++ xcframeworks (`libboost`, `libcommon.a`, `libcrypto_.a`, `libcurrency_core.a`, `libwallet.a`, `libz.a`, plus `openssl/`) before the build will succeed. These come from [`hyle-team/zano_native_lib_package_`](https://github.com/hyle-team/zano_native_lib_package_). If the build fails with missing modules or unresolved symbols, this is almost always the cause.
+
+## Repo layout
+
+- [zano-ios/](zano-ios/) — the Swift wrapper target (built into `zano_ios.xcframework`).
+- [zano-ios-sample/](zano-ios-sample/) — SwiftUI sample app demonstrating consumption.
+- [script.sh](script.sh) — xcframework build script.
+- [zano_ios.xcframework/](zano_ios.xcframework/) — most recently built artifact, checked in for convenience.

--- a/README.md
+++ b/README.md
@@ -4,15 +4,11 @@ A Swift wrapper around the Zano C++ wallet library, distributed as a prebuilt `z
 
 ## Consuming `zano_ios.xcframework` from an iOS app
 
-This is how [`wallet-ios`](https://github.com/bitcoin-portal/wallet-ios) consumes the library, and how any other iOS app should too. There is **no** Swift Package or CocoaPods distribution — the xcframework is dropped into the consuming repo directly.
+There is **no** Swift Package or CocoaPods distribution — the xcframework is dropped into the consuming repo directly.
 
 ### 1. Add the xcframework
 
-Copy `zano_ios.xcframework` into your app project. In `wallet-ios` it lives at:
-
-```
-BitcoinComWallet/Dependencies/zano_ios.xcframework
-```
+Copy `zano_ios.xcframework` into your app project. A common convention is a dedicated `Dependencies/` folder at the app target root, e.g. `YourApp/Dependencies/zano_ios.xcframework`.
 
 The xcframework bundles every transitive C++ dependency (`libboost`, `libwallet`, `libcrypto_`, etc.). You do **not** need to add anything from this repo's `zano-ios/Dependencies/` to your app — those are build-time-only inputs to `script.sh`.
 
@@ -42,21 +38,70 @@ All `ZanoWallet` methods return a JSON string from the underlying C++ wallet API
 
 The methods listed in `asyncCallMethods` ([zano-ios/zano.swift:13](zano-ios/zano.swift)) dispatch asynchronously inside the C++ layer; everything else is synchronous. Call them off the main thread.
 
-## Updating the xcframework shipped with `wallet-ios`
+## Updating to a new Zano library version
 
-When this library changes, rebuild and replace the copy in `wallet-ios`:
+A library version bump is a **two-PR workflow**: first land the rebuilt artifact in this repo, then update the consuming app to pick it up. For a worked library-side example, see [zano_native_lib_package_ios#7](https://github.com/bitcoin-portal/zano_native_lib_package_ios/pull/7).
+
+This fork has two git remotes:
+
+- `origin` → `bitcoin-portal/zano_native_lib_package_ios` (where we open PRs)
+- `upstream` → `hyle-team/zano_native_lib_package_ios` (where new C++ deps land first)
+
+### Step 1 — Pull the new C++ deps into this repo
+
+The upstream `hyle-team` repo is where new C++ builds (`libwallet`, `libboost`, `libcrypto_`, etc.) get bumped first. Sync from there:
 
 ```sh
-# In this repo:
-./script.sh                                  # produces ./zano_ios.xcframework
-
-# Then in wallet-ios:
-rm -rf BitcoinComWallet/Dependencies/zano_ios.xcframework
-cp -R ../zano_native_lib_package_ios/zano_ios.xcframework \
-      BitcoinComWallet/Dependencies/
+git fetch upstream
+git checkout -b update-zano-lib
+git merge upstream/main          # or cherry-pick the specific upstream commit
 ```
 
-Commit the replaced `zano_ios.xcframework` in `wallet-ios` — it is checked in directly, there is no remote artifact.
+The merge will refresh `zano-ios/Dependencies/` on disk. Those files are gitignored ([.gitignore](.gitignore) line 43) and will not appear in `git status`, but they're what the build links against.
+
+If `hyle-team` hasn't yet published the version you need, build the C++ side directly from [`hyle-team/zano_native_lib_package_`](https://github.com/hyle-team/zano_native_lib_package_) and copy its xcframework outputs into `zano-ios/Dependencies/` by hand.
+
+### Step 2 — Rebuild the xcframework
+
+```sh
+./script.sh
+```
+
+This produces `./zano_ios.xcframework`, overwriting the previously committed copy.
+
+### Step 3 — Smoke-test with the sample app
+
+Open `zano-ios.xcodeproj` in Xcode, select the `zano-ios-sample` scheme, and run on a simulator. If it launches and the basic wallet calls succeed, the rebuild is good.
+
+If the Swift public API changed (e.g. a new method on `ZanoWallet` or a renamed parameter), this is when you'll notice — patch the sample app along with anything else that needs to compile.
+
+### Step 4 — Open a PR in this repo
+
+Commit the rebuilt `zano_ios.xcframework/` (and any Swift source changes). `zano-ios/Dependencies/` stays gitignored — do not try to add it.
+
+```sh
+git add zano_ios.xcframework zano-ios   # plus zano-ios-sample if you touched it
+git commit -m "Update zano lib"
+git push -u origin update-zano-lib
+gh pr create --base main
+```
+
+### Step 5 — Open the matching PR in the consuming app
+
+In the consuming app's repo, replace its committed copy of the xcframework:
+
+```sh
+rm -rf <path/to>/zano_ios.xcframework
+cp -R ../zano_native_lib_package_ios/zano_ios.xcframework <path/to>/
+```
+
+A few things to expect:
+
+- **The consuming app's `.xcodeproj/project.pbxproj` will be modified automatically** when Xcode picks up the new framework hashes. The pbxproj churn is normal — commit it.
+- **Audit every consumer of `ZanoWallet`** for API changes. Additions are usually safe; renames or signature changes will surface as compile errors.
+- **Link the library PR as a blocker** in the consuming app's PR body so reviewers know the two need to merge together.
+
+The committed `zano_ios.xcframework` is the only artifact — there is no remote registry, no Swift Package, no CocoaPods.
 
 ## Building the xcframework
 


### PR DESCRIPTION
## Summary
- Rewrites the README around the consumer flow so iOS devs adding `zano_ios.xcframework` to their app (or maintaining the copy bundled in [`wallet-ios`](https://github.com/bitcoin-portal/wallet-ios)) have a single source of truth.
- Calls out the **Embed & Sign** requirement explicitly — using "Do Not Embed" runs fine on simulator but crashes TestFlight / App Store builds, which has burned us before.
- Documents the rebuild-and-replace workflow for updating the xcframework checked into `wallet-ios/BitcoinComWallet/Dependencies/`.
- Adds a note that `zano-ios/Dependencies/` is gitignored and must be populated from [`hyle-team/zano_native_lib_package_`](https://github.com/hyle-team/zano_native_lib_package_) before `script.sh` will build on a fresh clone.
- Drops the stale "move XCFrameworks from `Dependencies` folder into your app" step — those are build-time C++ inputs, not consumer-facing.

## Test plan
- [ ] Render the README on GitHub and confirm all relative links resolve (`zano-ios/zano.swift`, `zano-ios-sample/`, `zano-ios-sample/JSONRPC/`, `script.sh`).
- [ ] Confirm the Swift snippet compiles when copy-pasted into a host app with `zano_ios.xcframework` linked (sanity check, not a code change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)